### PR TITLE
Load JMSTranslationBundle in production environment

### DIFF
--- a/app/AppKernel.php
+++ b/app/AppKernel.php
@@ -37,15 +37,15 @@ class AppKernel extends Kernel
             new Surfnet\StepupMiddlewareClientBundle\SurfnetStepupMiddlewareClientBundle(),
             new Surfnet\SamlBundle\SurfnetSamlBundle(),
             new Surfnet\StepupBundle\SurfnetStepupBundle(),
+            new JMS\TranslationBundle\JMSTranslationBundle(),
+            new JMS\DiExtraBundle\JMSDiExtraBundle($this),
+            new JMS\AopBundle\JMSAopBundle(),
         );
 
         if (in_array($this->getEnvironment(), array('dev', 'test'))) {
             $bundles[] = new Symfony\Bundle\WebProfilerBundle\WebProfilerBundle();
             $bundles[] = new Sensio\Bundle\DistributionBundle\SensioDistributionBundle();
             $bundles[] = new Sensio\Bundle\GeneratorBundle\SensioGeneratorBundle();
-            $bundles[] = new JMS\TranslationBundle\JMSTranslationBundle();
-            $bundles[] = new JMS\DiExtraBundle\JMSDiExtraBundle($this);
-            $bundles[] = new JMS\AopBundle\JMSAopBundle();
         }
 
         return $bundles;

--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -139,3 +139,14 @@ surfnet_saml:
 surfnet_stepup:
     logging:
         application_name: self-service
+
+jms_translation:
+    locales: %locales%
+    configs:
+        default:
+            dirs: [%kernel.root_dir%/../src, %kernel.root_dir%, %kernel.root_dir%/../vendor/surfnet]
+            output_dir: %kernel.root_dir%/Resources/translations
+            ignored_domains: []
+            excluded_names: ['*TestCase.php', '*Test.php']
+            excluded_dirs: [cache, data, logs, Tests]
+            extractors: []

--- a/app/config/config_dev.yml
+++ b/app/config/config_dev.yml
@@ -40,14 +40,3 @@ nelmio_security:
         img: [ self, 'data:' ]
         script: [ self, unsafe-inline ]
         style: [ self, unsafe-inline ]
-
-jms_translation:
-    locales: %locales%
-    configs:
-        default:
-            dirs: [%kernel.root_dir%/../src, %kernel.root_dir%, %kernel.root_dir%/../vendor/surfnet]
-            output_dir: %kernel.root_dir%/Resources/translations
-            ignored_domains: []
-            excluded_names: ['*TestCase.php', '*Test.php']
-            excluded_dirs: [cache, data, logs, Tests]
-            extractors: []


### PR DESCRIPTION
The JMSTranslationBundle seems to be needed for the correct loading/reading of the generated XLIFF translation files.
