### PR TITLE
Always display empty Yubikey OTP field

### DIFF
--- a/src/Surfnet/StepupSelfService/SelfServiceBundle/Controller/Registration/YubikeyController.php
+++ b/src/Surfnet/StepupSelfService/SelfServiceBundle/Controller/Registration/YubikeyController.php
@@ -57,7 +57,7 @@ class YubikeyController extends Controller
             }
         }
 
-
+        // OTP field is rendered empty in the template.
         return ['form' => $form->createView()];
     }
 }

--- a/src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/Registration/Yubikey/provePossession.html.twig
+++ b/src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/Registration/Yubikey/provePossession.html.twig
@@ -21,6 +21,11 @@
 
     <hr>
 
-    {{ form(form) }}
+    {{ form_start(form) }}
+    {{ form_errors(form) }}
+
+    {{ form_row(form.otp, { value: '' }) }}
+
+    {{ form_end(form) }}
 
 {% endblock %}


### PR DESCRIPTION
![a](http://media0.giphy.com/media/R6xi8dXsRhIjK/200.gif)

> The Internet I scoured
> But my face has soured
> 'T is nix
> This solution, this fix

Alas, I used separate form calls to render the OTP field empty.