### PR TITLE
Remove the mobile phone number from URL

### DIFF
--- a/app/phpunit.xml.dist
+++ b/app/phpunit.xml.dist
@@ -9,7 +9,7 @@
 >
     <testsuites>
         <testsuite name="Project Test Suite">
-            <directory>../src/Tests</directory>
+            <directory>../src/Surfnet/StepupSelfService/SelfServiceBundle/Tests</directory>
         </testsuite>
     </testsuites>
 </phpunit>

--- a/build-pre-commit.xml
+++ b/build-pre-commit.xml
@@ -60,12 +60,17 @@
         <loadresource property="changeset.php.absolute.notests">
             <propertyresource name="changeset.php.absolute.newlinesep"/>
             <filterchain>
-                <tokenfilter>
-                    <containsregex pattern="src/(?!Tests).*$"/>
-                </tokenfilter>
+                <linecontains negate="true">
+                    <contains value="Tests"/>
+                </linecontains>
                 <trim/>
                 <ignoreblank/>
                 <tokenfilter delimoutput=","/>
+                <tokenfilter>
+                    <replaceregex pattern="(.*),$"
+                                  flags="s"
+                                  replace="\1"/>
+                </tokenfilter>
             </filterchain>
         </loadresource>
     </target>
@@ -118,7 +123,13 @@
         <echo message="OK"/>
     </target>
 
-    <target name="phpmd" depends="get-changeset.php-commasep.notests" if="changeset.php.notempty">
+    <target name="get-changeset.without-tests" depends="get-changeset.php-commasep.notests" if="changeset.php.notempty">
+        <condition property="changeset.php.absolute.notests.notempty">
+            <isset property="changeset.php.absolute.notests"/>
+        </condition>
+    </target>
+
+    <target name="phpmd" depends="get-changeset.without-tests" if="changeset.php.absolute.notests.notempty">
         <exec executable="${test-tree-location}/vendor/bin/phpmd" failonerror="true">
             <arg line="${changeset.php.absolute.notests} text ${test-tree-location}/phpmd-pre-commit.xml" />
         </exec>

--- a/build-pre-commit.xml
+++ b/build-pre-commit.xml
@@ -148,7 +148,7 @@
     </target>
 
     <target name="php-license" depends="get-changeset.php-spacesep" if="changeset.php.notempty">
-        <exec executable="/bin/grep" failonerror="true" outputproperty="php-license.grep.output">
+        <exec executable="/bin/grep" failonerror="false" outputproperty="php-license.grep.output">
             <arg value="-L"/>
             <arg value="LICENSE-2.0"/>
             <arg line="${changeset.php.absolute.spacesep}"/>

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,8 @@
     "require-dev": {
         "sensio/generator-bundle": "~2.3",
         "ibuildings/qa-tools": "~1.1,>=1.1.27",
-        "liip/rmt": "1.1.*"
+        "liip/rmt": "1.1.*",
+        "mockery/mockery": "0.9.*"
     },
     "repositories" : [
         {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at http://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "3271a3df2f430b654ec915948ebfe6d3",
+    "hash": "2cabf1ee7b6ea0e13634a31af7c565ad",
     "packages": [
         {
             "name": "beberlei/assert",
@@ -1747,12 +1747,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/SURFnet/Stepup-bundle.git",
-                "reference": "8be67228322d4fc4e55b57b44e12ae17e1f2cd8d"
+                "reference": "8bcadae4f4da17157ad0eec99525d6600c3aace2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/SURFnet/Stepup-bundle/zipball/8be67228322d4fc4e55b57b44e12ae17e1f2cd8d",
-                "reference": "8be67228322d4fc4e55b57b44e12ae17e1f2cd8d",
+                "url": "https://api.github.com/repos/SURFnet/Stepup-bundle/zipball/8bcadae4f4da17157ad0eec99525d6600c3aace2",
+                "reference": "8bcadae4f4da17157ad0eec99525d6600c3aace2",
                 "shasum": ""
             },
             "require": {
@@ -1788,7 +1788,7 @@
                 "suaas",
                 "surfnet"
             ],
-            "time": "2015-02-05 15:01:37"
+            "time": "2015-02-10 10:10:30"
         },
         {
             "name": "surfnet/stepup-middleware-client-bundle",
@@ -3101,6 +3101,72 @@
                 "version"
             ],
             "time": "2014-10-28 10:33:21"
+        },
+        {
+            "name": "mockery/mockery",
+            "version": "0.9.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/padraic/mockery.git",
+                "reference": "686f85fa5b3b079cc0157d7cd3e9adb97f0b41e1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/padraic/mockery/zipball/686f85fa5b3b079cc0157d7cd3e9adb97f0b41e1",
+                "reference": "686f85fa5b3b079cc0157d7cd3e9adb97f0b41e1",
+                "shasum": ""
+            },
+            "require": {
+                "lib-pcre": ">=7.0",
+                "php": ">=5.3.2"
+            },
+            "require-dev": {
+                "hamcrest/hamcrest-php": "~1.1",
+                "phpunit/phpunit": "~4.0",
+                "satooshi/php-coveralls": "~0.7@dev"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "0.9.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Mockery": "library/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Pádraic Brady",
+                    "email": "padraic.brady@gmail.com",
+                    "homepage": "http://blog.astrumfutura.com"
+                },
+                {
+                    "name": "Dave Marshall",
+                    "email": "dave.marshall@atstsolutions.co.uk",
+                    "homepage": "http://davedevelopment.co.uk"
+                }
+            ],
+            "description": "Mockery is a simple yet flexible PHP mock object framework for use in unit testing with PHPUnit, PHPSpec or any other testing framework. Its core goal is to offer a test double framework with a succint API capable of clearly defining all possible object operations and interactions using a human readable Domain Specific Language (DSL). Designed as a drop in alternative to PHPUnit's phpunit-mock-objects library, Mockery is easy to integrate with PHPUnit and can operate alongside phpunit-mock-objects without the World ending.",
+            "homepage": "http://github.com/padraic/mockery",
+            "keywords": [
+                "BDD",
+                "TDD",
+                "library",
+                "mock",
+                "mock objects",
+                "mockery",
+                "stub",
+                "test",
+                "test double",
+                "testing"
+            ],
+            "time": "2014-12-22 10:06:19"
         },
         {
             "name": "pdepend/pdepend",

--- a/src/Surfnet/StepupSelfService/SelfServiceBundle/Command/VerifySmsChallengeCommand.php
+++ b/src/Surfnet/StepupSelfService/SelfServiceBundle/Command/VerifySmsChallengeCommand.php
@@ -31,11 +31,6 @@ class VerifySmsChallengeCommand
     public $challenge;
 
     /**
-     * @var string
-     */
-    public $phoneNumber;
-
-    /**
      * The requesting identity's ID (not name ID).
      *
      * @var string

--- a/src/Surfnet/StepupSelfService/SelfServiceBundle/Controller/Registration/SmsController.php
+++ b/src/Surfnet/StepupSelfService/SelfServiceBundle/Controller/Registration/SmsController.php
@@ -47,7 +47,7 @@ class SmsController extends Controller
 
             if ($service->sendChallenge($command)) {
                 return $this->redirect(
-                    $this->generateUrl('ss_registration_sms_prove_possession', ['phoneNumber' => $command->recipient])
+                    $this->generateUrl('ss_registration_sms_prove_possession')
                 );
             } else {
                 $form->addError(new FormError('ss.prove_phone_possession.send_sms_challenge_failed'));
@@ -60,13 +60,12 @@ class SmsController extends Controller
     /**
      * @Template
      */
-    public function provePossessionAction(Request $request, $phoneNumber)
+    public function provePossessionAction(Request $request)
     {
         $identity = $this->getIdentity();
 
         $command = new VerifySmsChallengeCommand();
         $command->identity = $identity->id;
-        $command->phoneNumber = $phoneNumber;
 
         $form = $this->createForm('ss_verify_sms_challenge', $command)->handleRequest($request);
 

--- a/src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/config/routing.yml
+++ b/src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/config/routing.yml
@@ -46,7 +46,7 @@ ss_registration_sms_send_challenge:
     defaults: { _controller: SurfnetStepupSelfServiceSelfServiceBundle:Registration/Sms:sendChallenge }
 
 ss_registration_sms_prove_possession:
-    path:     /registration/sms/prove-possession/{phoneNumber}
+    path:     /registration/sms/prove-possession
     methods:  [GET,POST]
     defaults: { _controller: SurfnetStepupSelfServiceSelfServiceBundle:Registration/Sms:provePossession }
 

--- a/src/Surfnet/StepupSelfService/SelfServiceBundle/Service/SmsSecondFactor/ChallengeStore.php
+++ b/src/Surfnet/StepupSelfService/SelfServiceBundle/Service/SmsSecondFactor/ChallengeStore.php
@@ -21,17 +21,19 @@ namespace Surfnet\StepupSelfService\SelfServiceBundle\Service\SmsSecondFactor;
 interface ChallengeStore
 {
     /**
-     * Generates a challenge, stores it and returns it.
+     * Generates a challenge for a specific phone number, stores it and returns it.
      *
+     * @param string $phoneNumber
      * @return string
      */
-    public function generateChallenge();
+    public function generateChallenge($phoneNumber);
 
     /**
-     * Verifies a previously generated challenge.
+     * Verifies a previously generated challenge and returns the phone number associated with it. After 'taking' it, it
+     * is no longer available.
      *
      * @param string $challenge
-     * @return bool
+     * @return string|null The phone number that matches the given challenge.
      */
-    public function verifyChallenge($challenge);
+    public function takePhoneNumberMatchingChallenge($challenge);
 }

--- a/src/Surfnet/StepupSelfService/SelfServiceBundle/Service/SmsSecondFactor/SessionChallengeStore.php
+++ b/src/Surfnet/StepupSelfService/SelfServiceBundle/Service/SmsSecondFactor/SessionChallengeStore.php
@@ -42,7 +42,7 @@ class SessionChallengeStore implements ChallengeStore
         $this->sessionKey = $sessionKey;
     }
 
-    public function generateChallenge()
+    public function generateChallenge($phoneNumber)
     {
         $randomCharacters = function () {
             $chr = rand(50, 81);
@@ -52,18 +52,16 @@ class SessionChallengeStore implements ChallengeStore
         };
         $challenge = join('', array_map('chr', array_map($randomCharacters, range(1, 8))));
 
-        $this->session->set($this->sessionKey, $challenge);
+        $this->session->set($this->sessionKey . '/' . $challenge, $phoneNumber);
 
         return $challenge;
     }
 
-    public function verifyChallenge($challenge)
+    public function takePhoneNumberMatchingChallenge($challenge)
     {
         $challenge = strtoupper($challenge);
-        $expectedChallenge = $this->session->get($this->sessionKey);
+        $phoneNumber = $this->session->remove($this->sessionKey . '/' . $challenge);
 
-        $this->session->remove($this->sessionKey);
-
-        return $expectedChallenge !== null && $challenge === $expectedChallenge;
+        return $phoneNumber;
     }
 }

--- a/src/Surfnet/StepupSelfService/SelfServiceBundle/Tests/Service/SmsSecondFactor/SessionChallengeStoreTest.php
+++ b/src/Surfnet/StepupSelfService/SelfServiceBundle/Tests/Service/SmsSecondFactor/SessionChallengeStoreTest.php
@@ -1,5 +1,21 @@
 <?php
 
+/**
+ * Copyright 2014 SURFnet bv
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 namespace Surfnet\StepupSelfService\SelfServiceBundle\Tests\Service\SmsSecondFactor;
 
 use Mockery as m;

--- a/src/Surfnet/StepupSelfService/SelfServiceBundle/Tests/Service/SmsSecondFactor/SessionChallengeStoreTest.php
+++ b/src/Surfnet/StepupSelfService/SelfServiceBundle/Tests/Service/SmsSecondFactor/SessionChallengeStoreTest.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace Surfnet\StepupSelfService\SelfServiceBundle\Tests\Service\SmsSecondFactor;
+
+use Mockery as m;
+use PHPUnit_Framework_TestCase as TestCase;
+use Surfnet\StepupSelfService\SelfServiceBundle\Service\SmsSecondFactor\SessionChallengeStore;
+
+class SessionChallengeStoreTest extends TestCase
+{
+    public function test_it_can_generate_challenges()
+    {
+        $session = m::mock('Symfony\Component\HttpFoundation\Session\SessionInterface');
+        $session->shouldReceive('set')->once()->with(m::type('string'), '123456789');
+
+        $store = new SessionChallengeStore($session, 'sess');
+        $challenge = $store->generateChallenge('123456789');
+
+        $this->assertInternalType('string', $challenge);
+        $this->assertNotEmpty($challenge);
+    }
+
+    public function test_the_phone_number_associated_with_a_generated_challenge_can_be_retrieved_later()
+    {
+        $session = m::mock('Symfony\Component\HttpFoundation\Session\SessionInterface');
+        $session->shouldReceive('set')->once()->with(self::spy($spiedSessionKey), '123456789');
+
+        $store = new SessionChallengeStore($session, 'sess');
+        $challenge = $store->generateChallenge('123456789');
+
+        $expectedSessionKey = "sess/$challenge";
+        $session->shouldReceive('remove')->once()->with($expectedSessionKey)->andReturn('123456789');
+        $phoneNumber = $store->takePhoneNumberMatchingChallenge($challenge);
+
+        $this->assertEquals($expectedSessionKey, $spiedSessionKey);
+        $this->assertEquals('123456789', $phoneNumber);
+        $this->assertInternalType('string', $challenge);
+        $this->assertNotEmpty($challenge);
+    }
+
+    public function test_the_phone_number_associated_with_a_generated_challenge_can_be_retrieved_later_regardless_of_challenge_casing()
+    {
+        $session = m::mock('Symfony\Component\HttpFoundation\Session\SessionInterface');
+        $session->shouldIgnoreMissing();
+
+        $store = new SessionChallengeStore($session, 'sess');
+        $challenge = $store->generateChallenge('123456789');
+
+        $expectedSessionKey = "sess/$challenge";
+        $session->shouldReceive('remove')->once()->with($expectedSessionKey)->andReturn('123456789');
+        $phoneNumber = $store->takePhoneNumberMatchingChallenge(strtolower($challenge));
+
+        $this->assertEquals('123456789', $phoneNumber);
+    }
+
+    public function test_the_phone_number_associated_with_a_generated_challenge_can_be_retrieved_only_once()
+    {
+        $session = m::mock('Symfony\Component\HttpFoundation\Session\SessionInterface');
+        $session->shouldIgnoreMissing();
+
+        $store = new SessionChallengeStore($session, 'sess');
+        $challenge = $store->generateChallenge('123456789');
+
+        $expectedSessionKey = "sess/$challenge";
+        $session->shouldReceive('remove')->once()->with($expectedSessionKey)->andReturn('123456789');
+        $session->shouldReceive('remove')->once()->with($expectedSessionKey)->andReturn(null);
+        $store->takePhoneNumberMatchingChallenge($challenge);
+        $phoneNumber = $store->takePhoneNumberMatchingChallenge($challenge);
+
+        $this->assertEquals(null, $phoneNumber);
+    }
+
+    public function test_an_unknown_challenge_returns_phone_number_null()
+    {
+        $session = m::mock('Symfony\Component\HttpFoundation\Session\SessionInterface');
+        $session->shouldIgnoreMissing();
+
+        $store = new SessionChallengeStore($session, 'sess');
+        $expectedSessionKey = "sess/MYCHALLENGE";
+        $session->shouldReceive('remove')->once()->with($expectedSessionKey)->andReturn(null);
+        $phoneNumber = $store->takePhoneNumberMatchingChallenge('MYCHALLENGE');
+
+        $this->assertEquals(null, $phoneNumber);
+    }
+
+    private static function spy(&$spy)
+    {
+        return m::on(function ($value) use (&$spy) {
+            $spy = $value;
+
+            return true;
+        });
+    }
+}


### PR DESCRIPTION
Terminology explanation for [this diff line](https://github.com/SURFnet/Stepup-SelfService/commit/93b7322b1b6ab71500255f24d83f98f7b0b84c0c#diff-ae1f51068dfaf8da2e870c6fb62e5249L36): 'taking' implies a side effect (reading and removing the phone number) as opposed to 'getting', which implies no side effects.