### PR TITLE
Render informative error screens in case of the below resp. statuses.

### DIFF
--- a/app/Resources/translations/messages.en_GB.xliff
+++ b/app/Resources/translations/messages.en_GB.xliff
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:jms="urn:jms:translation" version="1.2">
-  <file date="2015-02-18T16:07:24Z" source-language="en" target-language="en_GB" datatype="plaintext" original="not.available">
+  <file date="2015-02-23T14:52:19Z" source-language="en" target-language="en_GB" datatype="plaintext" original="not.available">
     <header>
       <tool tool-id="JMSTranslationBundle" tool-name="JMSTranslationBundle" tool-version="1.1.0-DEV"/>
       <note>The source node in most cases contains the sample message as written by the developer. If it looks like a dot-delimitted string such as "form.label.firstname", then the developer has not provided a default message.</note>
@@ -22,6 +22,31 @@
         <jms:reference-file line="3">views/Exception/error404.html.twig</jms:reference-file>
         <source>ss.error.page_not_found.title</source>
         <target>Page not found</target>
+      </trans-unit>
+      <trans-unit id="865517641b0d0da94788635ac950e5cbbded97a1" resname="ss.error.saml_authn_failed.button.try_again">
+        <jms:reference-file line="10">Saml/Exception/authnFailed.html.twig</jms:reference-file>
+        <source>ss.error.saml_authn_failed.button.try_again</source>
+        <target>Retry sign-in</target>
+      </trans-unit>
+      <trans-unit id="39ad001351f2f524be4a7136f8facdb65097ce59" resname="ss.error.saml_authn_failed.text.authn_failed">
+        <jms:reference-file line="8">Saml/Exception/authnFailed.html.twig</jms:reference-file>
+        <source>ss.error.saml_authn_failed.text.authn_failed</source>
+        <target>You were unable to sign in.</target>
+      </trans-unit>
+      <trans-unit id="e437d473b6267a6996aa245eb7d1a711c5a395c4" resname="ss.error.saml_authn_failed.title">
+        <jms:reference-file line="3">Saml/Exception/authnFailed.html.twig</jms:reference-file>
+        <source>ss.error.saml_authn_failed.title</source>
+        <target>Sign in</target>
+      </trans-unit>
+      <trans-unit id="9bdaf74a75cfffab8e0de6c6258c9ddfaf7cb025" resname="ss.error.saml_precondition_not_met.text.precondition_not_met">
+        <jms:reference-file line="8">Saml/Exception/preconditionNotMet.html.twig</jms:reference-file>
+        <source>ss.error.saml_precondition_not_met.text.precondition_not_met</source>
+        <target>You don't meet all the requirements to be able to sign into the Self-Service application.</target>
+      </trans-unit>
+      <trans-unit id="6fc7fed55f78c4586ff617bd890dd35c3f63b338" resname="ss.error.saml_precondition_not_met.title">
+        <jms:reference-file line="3">Saml/Exception/preconditionNotMet.html.twig</jms:reference-file>
+        <source>ss.error.saml_precondition_not_met.title</source>
+        <target>Sign in</target>
       </trans-unit>
       <trans-unit id="0187a2e37be4b12710d8b3a3c4e2d5a8dc30e18e" resname="ss.error.text.an_error_occurred">
         <jms:reference-file line="8">views/Exception/error.html.twig</jms:reference-file>

--- a/app/Resources/translations/messages.nl_NL.xliff
+++ b/app/Resources/translations/messages.nl_NL.xliff
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:jms="urn:jms:translation" version="1.2">
-  <file date="2015-02-18T16:07:41Z" source-language="en" target-language="nl_NL" datatype="plaintext" original="not.available">
+  <file date="2015-02-23T14:52:03Z" source-language="en" target-language="nl_NL" datatype="plaintext" original="not.available">
     <header>
       <tool tool-id="JMSTranslationBundle" tool-name="JMSTranslationBundle" tool-version="1.1.0-DEV"/>
       <note>The source node in most cases contains the sample message as written by the developer. If it looks like a dot-delimitted string such as "form.label.firstname", then the developer has not provided a default message.</note>
@@ -22,6 +22,31 @@
         <jms:reference-file line="3">views/Exception/error404.html.twig</jms:reference-file>
         <source>ss.error.page_not_found.title</source>
         <target>Pagina niet gevonden</target>
+      </trans-unit>
+      <trans-unit id="865517641b0d0da94788635ac950e5cbbded97a1" resname="ss.error.saml_authn_failed.button.try_again">
+        <jms:reference-file line="10">Saml/Exception/authnFailed.html.twig</jms:reference-file>
+        <source>ss.error.saml_authn_failed.button.try_again</source>
+        <target>Opnieuw inloggen</target>
+      </trans-unit>
+      <trans-unit id="39ad001351f2f524be4a7136f8facdb65097ce59" resname="ss.error.saml_authn_failed.text.authn_failed">
+        <jms:reference-file line="8">Saml/Exception/authnFailed.html.twig</jms:reference-file>
+        <source>ss.error.saml_authn_failed.text.authn_failed</source>
+        <target>U heeft niet in kunnen loggen.</target>
+      </trans-unit>
+      <trans-unit id="e437d473b6267a6996aa245eb7d1a711c5a395c4" resname="ss.error.saml_authn_failed.title">
+        <jms:reference-file line="3">Saml/Exception/authnFailed.html.twig</jms:reference-file>
+        <source>ss.error.saml_authn_failed.title</source>
+        <target>Inloggen</target>
+      </trans-unit>
+      <trans-unit id="9bdaf74a75cfffab8e0de6c6258c9ddfaf7cb025" resname="ss.error.saml_precondition_not_met.text.precondition_not_met">
+        <jms:reference-file line="8">Saml/Exception/preconditionNotMet.html.twig</jms:reference-file>
+        <source>ss.error.saml_precondition_not_met.text.precondition_not_met</source>
+        <target>U voldoet niet aan alle voorwaarden om in te mogen loggen bij de Self-Service-applicatie.</target>
+      </trans-unit>
+      <trans-unit id="6fc7fed55f78c4586ff617bd890dd35c3f63b338" resname="ss.error.saml_precondition_not_met.title">
+        <jms:reference-file line="3">Saml/Exception/preconditionNotMet.html.twig</jms:reference-file>
+        <source>ss.error.saml_precondition_not_met.title</source>
+        <target>Inloggen</target>
       </trans-unit>
       <trans-unit id="0187a2e37be4b12710d8b3a3c4e2d5a8dc30e18e" resname="ss.error.text.an_error_occurred">
         <jms:reference-file line="8">views/Exception/error.html.twig</jms:reference-file>

--- a/composer.lock
+++ b/composer.lock
@@ -1845,12 +1845,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/SURFnet/Stepup-saml-bundle.git",
-                "reference": "bca2609f8238122b0a86f8119868ce60f2016b37"
+                "reference": "f3be91f57c802ead44307ca94ace3774f1e8b090"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/SURFnet/Stepup-saml-bundle/zipball/bca2609f8238122b0a86f8119868ce60f2016b37",
-                "reference": "bca2609f8238122b0a86f8119868ce60f2016b37",
+                "url": "https://api.github.com/repos/SURFnet/Stepup-saml-bundle/zipball/f3be91f57c802ead44307ca94ace3774f1e8b090",
+                "reference": "f3be91f57c802ead44307ca94ace3774f1e8b090",
                 "shasum": ""
             },
             "require": {
@@ -1883,7 +1883,7 @@
                 "stepup",
                 "surfnet"
             ],
-            "time": "2015-02-05 13:05:01"
+            "time": "2015-02-23 13:01:51"
         },
         {
             "name": "swiftmailer/swiftmailer",

--- a/src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/config/services.yml
+++ b/src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/config/services.yml
@@ -99,6 +99,7 @@ services:
             - @self_service.security.authentication.saml
             - @self_service.security.authentication.session_handler
             - @logger
+            - @twig
 
     self_service.security.authentication.saml:
         public: false

--- a/src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/Saml/Exception/authnFailed.html.twig
+++ b/src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/Saml/Exception/authnFailed.html.twig
@@ -1,0 +1,12 @@
+{% extends '::base.html.twig' %}
+
+{% block page_title %}{{ 'ss.error.saml_authn_failed.title'|trans }}{% endblock %}
+
+{% block content %}
+    <h2>{{ block('page_title') }}</h2>
+
+    <p>{{ 'ss.error.saml_authn_failed.text.authn_failed'|trans }}</p>
+    <a class="btn btn-primary" href="{{ path('ss_entry_point') }}">
+        {{ 'ss.error.saml_authn_failed.button.try_again'|trans }}
+    </a>
+{% endblock %}

--- a/src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/Saml/Exception/preconditionNotMet.html.twig
+++ b/src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/Saml/Exception/preconditionNotMet.html.twig
@@ -1,0 +1,9 @@
+{% extends '::base.html.twig' %}
+
+{% block page_title %}{{ 'ss.error.saml_precondition_not_met.title'|trans }}{% endblock %}
+
+{% block content %}
+    <h2>{{ block('page_title') }}</h2>
+
+    <p>{{ 'ss.error.saml_precondition_not_met.text.precondition_not_met'|trans }}</p>
+{% endblock %}


### PR DESCRIPTION
 - AuthnFailed - IdP failed to authenticate user
 - * - All other cases where preconditions weren't met

The reason the response is rendered and set from the SamlListener and
not from a kernel listener is the fact that the firewall errors out
when the listener doesn't set a token.