### PR TITLE
Fix issue where tiqr registration could not start

### DIFF
--- a/src/Surfnet/StepupSelfService/SamlStepupProviderBundle/DependencyInjection/SurfnetStepupSelfServiceSamlStepupProviderExtension.php
+++ b/src/Surfnet/StepupSelfService/SamlStepupProviderBundle/DependencyInjection/SurfnetStepupSelfServiceSamlStepupProviderExtension.php
@@ -102,8 +102,10 @@ class SurfnetStepupSelfServiceSamlStepupProviderExtension extends Extension
 
         $hostedSpDefinition  = (new Definition())
             ->setClass('Surfnet\SamlBundle\Entity\ServiceProvider')
-            ->setFactoryService(new Reference('gssp.provider.' . $provider . '.hosted_entities'))
-            ->setFactoryMethod('getServiceProvider')
+            ->setFactory([
+                new Reference('gssp.provider.' . $provider . '.hosted_entities'),
+                'getServiceProvider'
+            ])
             ->setPublic(false);
         $container->setDefinition('gssp.provider.' . $provider . '.hosted.sp', $hostedSpDefinition);
     }


### PR DESCRIPTION
the factory definition used was broken for some reason this was never caught in dev or test. Might have to do something with the 300+ commits between SF 2.6.4 and 2.6.6....