### PR TITLE
Implement locale cookie listener from StepupBundle into SelfService

### DIFF
--- a/src/Surfnet/StepupSelfService/SelfServiceBundle/EventListener/LocaleListener.php
+++ b/src/Surfnet/StepupSelfService/SelfServiceBundle/EventListener/LocaleListener.php
@@ -18,36 +18,48 @@
 
 namespace Surfnet\StepupSelfService\SelfServiceBundle\EventListener;
 
-use Surfnet\StepupSelfService\SelfServiceBundle\Service\LocaleProviderService;
+use Surfnet\StepupMiddlewareClientBundle\Identity\Dto\Identity;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpKernel\Event\GetResponseEvent;
 use Symfony\Component\HttpKernel\KernelEvents;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Symfony\Component\Translation\TranslatorInterface;
 
 final class LocaleListener implements EventSubscriberInterface
 {
     /**
-     * @var LocaleProviderService
+     * @var \Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface
      */
-    private $localeProviderService;
+    private $tokenStorage;
 
     /**
      * @var TranslatorInterface
      */
     private $translator;
 
-    public function __construct(LocaleProviderService $localeProviderService, TranslatorInterface $translator)
+    public function __construct(TokenStorageInterface $tokenStorage, TranslatorInterface $translator)
     {
-        $this->localeProviderService = $localeProviderService;
+        $this->tokenStorage = $tokenStorage;
         $this->translator = $translator;
     }
 
     public function setRequestLocale(GetResponseEvent $event)
     {
-        $preferredLocale = $this->localeProviderService->determinePreferredLocale();
+        $token = $this->tokenStorage->getToken();
+
+        if (!$token) {
+            return;
+        }
+
+        $identity = $token->getUser();
+
+        // Anonymous usage like /authentication/metadata has just "anonymous" as identity.
+        if (!$identity instanceof Identity) {
+            return;
+        }
 
         $request = $event->getRequest();
-        $request->setLocale($preferredLocale);
+        $request->setLocale($identity->preferredLocale);
 
         // As per \Symfony\Component\HttpKernel\EventListener\TranslatorListener::setLocale()
         try {

--- a/src/Surfnet/StepupSelfService/SelfServiceBundle/EventListener/LocaleListener.php
+++ b/src/Surfnet/StepupSelfService/SelfServiceBundle/EventListener/LocaleListener.php
@@ -18,48 +18,36 @@
 
 namespace Surfnet\StepupSelfService\SelfServiceBundle\EventListener;
 
-use Surfnet\StepupMiddlewareClientBundle\Identity\Dto\Identity;
+use Surfnet\StepupSelfService\SelfServiceBundle\Service\LocaleProviderService;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpKernel\Event\GetResponseEvent;
 use Symfony\Component\HttpKernel\KernelEvents;
-use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Symfony\Component\Translation\TranslatorInterface;
 
 final class LocaleListener implements EventSubscriberInterface
 {
     /**
-     * @var \Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface
+     * @var LocaleProviderService
      */
-    private $tokenStorage;
+    private $localeProviderService;
 
     /**
      * @var TranslatorInterface
      */
     private $translator;
 
-    public function __construct(TokenStorageInterface $tokenStorage, TranslatorInterface $translator)
+    public function __construct(LocaleProviderService $localeProviderService, TranslatorInterface $translator)
     {
-        $this->tokenStorage = $tokenStorage;
+        $this->localeProviderService = $localeProviderService;
         $this->translator = $translator;
     }
 
     public function setRequestLocale(GetResponseEvent $event)
     {
-        $token = $this->tokenStorage->getToken();
-
-        if (!$token) {
-            return;
-        }
-
-        $identity = $token->getUser();
-
-        // Anonymous usage like /authentication/metadata has just "anonymous" as identity.
-        if (!$identity instanceof Identity) {
-            return;
-        }
+        $preferredLocale = $this->localeProviderService->determinePreferredLocale();
 
         $request = $event->getRequest();
-        $request->setLocale($identity->preferredLocale);
+        $request->setLocale($preferredLocale);
 
         // As per \Symfony\Component\HttpKernel\EventListener\TranslatorListener::setLocale()
         try {

--- a/src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/config/services.yml
+++ b/src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/config/services.yml
@@ -122,7 +122,7 @@ services:
 
     self_service.event_listener.locale:
         class: Surfnet\StepupSelfService\SelfServiceBundle\EventListener\LocaleListener
-        arguments: [ "@security.token_storage", "@translator" ]
+        arguments: [ "@self_service.service.locale_provider", "@translator" ]
         tags: [{ name: kernel.event_subscriber }]
 
     self_service.event_listener.locale_cookie:

--- a/src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/config/services.yml
+++ b/src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/config/services.yml
@@ -125,6 +125,15 @@ services:
         arguments: [ "@security.token_storage", "@translator" ]
         tags: [{ name: kernel.event_subscriber }]
 
+    self_service.event_listener.locale_cookie:
+        class: Surfnet\StepupBundle\EventListener\LocaleCookieListener
+        arguments:
+            - "@surfnet_stepup.locale_cookie_helper"
+            - "@self_service.service.locale_provider"
+            - "@logger"
+        tags:
+            - { name: kernel.event_listener, event: kernel.response, method: onKernelResponse, priority: 6 }
+
     self_service.locale.request_stack_locale_provider:
         class: Surfnet\StepupSelfService\SelfServiceBundle\Locale\RequestStackLocaleProvider
         arguments:

--- a/src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/config/services.yml
+++ b/src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/config/services.yml
@@ -122,7 +122,7 @@ services:
 
     self_service.event_listener.locale:
         class: Surfnet\StepupSelfService\SelfServiceBundle\EventListener\LocaleListener
-        arguments: [ "@self_service.service.locale_provider", "@translator" ]
+        arguments: [ "@security.token_storage", "@translator" ]
         tags: [{ name: kernel.event_subscriber }]
 
     self_service.event_listener.locale_cookie:

--- a/src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/config/services.yml
+++ b/src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/config/services.yml
@@ -100,6 +100,11 @@ services:
             - "@security.token_storage"
             - "@logger"
 
+    self_service.service.locale_provider:
+        class: Surfnet\StepupSelfService\SelfServiceBundle\Service\LocaleProviderService
+        arguments:
+            - "@security.token_storage"
+
     self_service.service.ra:
         class: Surfnet\StepupSelfService\SelfServiceBundle\Service\RaService
         arguments:

--- a/src/Surfnet/StepupSelfService/SelfServiceBundle/Security/Authentication/Handler/ExplicitSessionTimeoutHandler.php
+++ b/src/Surfnet/StepupSelfService/SelfServiceBundle/Security/Authentication/Handler/ExplicitSessionTimeoutHandler.php
@@ -28,6 +28,9 @@ use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInt
 use Symfony\Component\Security\Http\Logout\CookieClearingLogoutHandler;
 use Symfony\Component\Security\Http\Logout\SessionLogoutHandler;
 
+/**
+ * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
+ */
 class ExplicitSessionTimeoutHandler implements AuthenticationHandler
 {
     /**

--- a/src/Surfnet/StepupSelfService/SelfServiceBundle/Service/LocaleProviderService.php
+++ b/src/Surfnet/StepupSelfService/SelfServiceBundle/Service/LocaleProviderService.php
@@ -1,0 +1,54 @@
+<?php
+
+/**
+ * Copyright 2016 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Surfnet\StepupSelfService\SelfServiceBundle\Service;
+
+use Surfnet\StepupBundle\Service\LocaleProviderService as StepupLocaleProviderService;
+use Surfnet\StepupMiddlewareClientBundle\Identity\Dto\Identity;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
+
+final class LocaleProviderService implements StepupLocaleProviderService
+{
+    /**
+     * @var TokenStorageInterface
+     */
+    private $tokenStorage;
+
+    public function __construct(TokenStorageInterface $tokenStorage)
+    {
+        $this->tokenStorage = $tokenStorage;
+    }
+
+    public function determinePreferredLocale()
+    {
+        $token = $this->tokenStorage->getToken();
+
+        if (!$token) {
+            return;
+        }
+
+        /** @var Identity $identity */
+        $identity = $token->getUser();
+
+        if (!$identity instanceof Identity) {
+            return;
+        }
+
+        return $identity->preferredLocale;
+    }
+}


### PR DESCRIPTION
[113611545](https://www.pivotaltracker.com/story/show/113611545)

This implements the locale cookie listener from the StepupBundle into SelfService.

For its RA counter-part, see: [Stepup-RA #123](https://github.com/SURFnet/Stepup-RA/pull/123).