### PR TITLE
Update button layout on token overview page

### DIFF
--- a/src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/public/less/style.less
+++ b/src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/public/less/style.less
@@ -110,9 +110,11 @@ select[name="stepup_switch_locale[locale]"] {
         margin-right: 5px;
     }
 }
-.m-t-2 {
-    margin-top: 2em;
+
+.token-button-group {
+    margin: -4px 8px 0 0;
 }
+
 
 .table-striped tbody td {
     vertical-align: middle !important;

--- a/src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/SecondFactor/list.html.twig
+++ b/src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/SecondFactor/list.html.twig
@@ -10,6 +10,13 @@
     {{ macro.secondFactorTable(verifiedSecondFactors, 'ss.second_factor.list.text.verified', 'verified', email, expirationHelper) }}
     {{ macro.secondFactorTable(unverifiedSecondFactors, 'ss.second_factor.list.text.unverified', 'unverified', email, expirationHelper) }}
 
+    <div class="btn-toolbar token-button-group" role="toolbar">
+    {% if vettedSecondFactors.elements is not empty %}
+        <a class="btn btn-default pull-right" href="{{ path('ss_second_factor_test') }}">
+            {{ 'ss.second_factor.revoke.button.test'|trans }}
+        </a>
+    {% endif %}
+
     {% if registrationsLeft > 0
             and ((unverifiedSecondFactors.elements is empty and verifiedSecondFactors.elements is empty and vettedSecondFactors.elements is empty)
             or availableSecondFactors is not empty)
@@ -17,11 +24,12 @@
         {% if (unverifiedSecondFactors.elements is empty and verifiedSecondFactors.elements is empty and vettedSecondFactors.elements is empty) %}
             <p>{{ 'ss.second_factor.list.text.no_second_factors'|trans }}</p>
         {% endif %}
-            <a href="{{ path('ss_registration_display_types') }}"
-               class="btn btn-primary m-t-2">
-                {{ 'ss.second_factor.list.button.register_second_factor'|trans }}
-            </a>
+        <a href="{{ path('ss_registration_display_types') }}"
+           class="btn btn-primary pull-right">
+            {{ 'ss.second_factor.list.button.register_second_factor'|trans }}
+        </a>
     {% endif %}
+    </div>
 
 {% endblock %}
 
@@ -67,17 +75,7 @@
                         </tr>
                     {% endfor %}
                     </tbody>
-                    {% if state == 'vetted' %}
-                    <tfoot>
-                        <tr>
-                            <td colspan="4">
-                                <a class="btn btn-mini btn-default pull-right" href="{{ path('ss_second_factor_test') }}">
-                                    {{ 'ss.second_factor.revoke.button.test'|trans }}
-                                </a>
-                            </td>
-                        </tr>
-                    </tfoot>
-                    {% endif %}
+
                 </table>
 
                 {% if hasExpired %}


### PR DESCRIPTION
The test and add buttons are now shown in a seperate button group.
Previously the add and test buttons where placed in the table footer
and at the bottom of the page. This new solution allows us to group
the buttons next to each other, providing a cleaner page layout.

[Pivotal #156912398](https://www.pivotaltracker.com/story/show/156912398)