### PR TITLE
Replace forms with a-href links

### DIFF
--- a/config/routes.yaml
+++ b/config/routes.yaml
@@ -13,4 +13,4 @@ nelmio_security_report:
 
 logout:
     path: /logout
-    methods: [POST]
+    methods: [GET]

--- a/src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/registration/display_vetting_types.html.twig
+++ b/src/Surfnet/StepupSelfService/SelfServiceBundle/Resources/views/registration/display_vetting_types.html.twig
@@ -39,9 +39,9 @@
                   <h3>{{ 'ss.registration.vetting_type.title.self_vet'|trans }}</h3>
                   <hr>
                   <p>{{ 'ss.registration.vetting_type.description.self_vet'|trans }}</p>
-                  <form action="{{ url('ss_second_factor_self_vet', {'secondFactorId': secondFactorId}) }}" method="get">
+                  <a href="{{ url('ss_second_factor_self_vet', {'secondFactorId': secondFactorId}) }}">
                       <button type="submit" class="btn btn-primary">{{ 'ss.registration.vetting_type.button.self_vet'|trans }}</button>
-                  </form>
+                  </a>
               </div>
           </div>
         {% endif %}
@@ -53,9 +53,9 @@
                     <h3>{{ 'ss.registration.vetting_type.title.self_asserted_tokens'|trans }}</h3>
                     <hr>
                     <p>{{ 'ss.registration.vetting_type.description.self_asserted_tokens'|trans }}</p>
-                    <form action="{{ url('ss_second_factor_self_asserted_tokens', {'secondFactorId': secondFactorId}) }}" method="get">
+                    <a href="{{ url('ss_second_factor_self_asserted_tokens', {'secondFactorId': secondFactorId}) }}">
                         <button type="submit" class="btn btn-primary">{{ 'ss.registration.vetting_type.button.self_asserted_tokens'|trans }}</button>
-                    </form>
+                    </a>
                 </div>
             </div>
         {% endif %}
@@ -66,9 +66,9 @@
                 <h3>{{ 'ss.registration.vetting_type.title.ra_vetting'|trans }}</h3>
                 <hr>
                 <p>{{ 'ss.registration.vetting_type.description.ra_vetting'|trans }}</p>
-                <form action="{{ url('ss_registration_send_registration_email', {'secondFactorId': secondFactorId}) }}" method="get">
+                <a href="{{ url('ss_registration_send_registration_email', {'secondFactorId': secondFactorId}) }}">
                     <button type="submit" class="btn btn-primary">{{ 'ss.registration.vetting_type.button.ra_vetting'|trans }}</button>
-                </form>
+                </a>
             </div>
         </div>
     </div>

--- a/templates/base.html.twig
+++ b/templates/base.html.twig
@@ -45,12 +45,12 @@
         </div>
         {% if app.user %}
             <div class="clearfix page-header-user">
-                <form method="post" action="{{ logout_url('saml_based') }}" class="pull-right">
+                <a href="{{ logout_url('saml_based') }}" class="pull-right">
                     <button type="submit" class="btn btn-link">
                         <i class="fa fa-sign-out"></i>
                         {{ 'button.logout'|trans }}
                     </button>
-                </form>
+                </a>
                 {% set locale_switcher = stepup_locale_switcher(app.request.locale, 'ss_switch_locale', {'return-url': app.request.uri}) %}
                 {{ form_start(locale_switcher, { attr: { class: 'form-inline' }}) }}
                 {{ form_widget(locale_switcher.locale) }}


### PR DESCRIPTION
When setting a Content-Security-Policy with `form-action *.<your-domain>.nl`, the forms won't work in Edge/Chrome.
See [this](https://content-security-policy.com/form-action/) article, paragraph "Can the form-action redirect to another url?" for the reason behind this. TL;DR: Edge/Chrome does not allow the form's POST-destination to perform a redirect.
Replacing the unnecessary forms with simple links resolves this issue and allows for a stricter CSP-policy.

Previously discussed on Slack with @MKodde 